### PR TITLE
detect dark theme preference

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,9 @@ twitter_username: randypgaul
 github_username:  randygaul
 
 # Build settings
-theme: minima
+remote_theme: jekyll/minima
+minima:
+  skin: auto
 plugins:
   - jekyll-feed
 


### PR DESCRIPTION
This enables dark theme, detected through user/browser/system settings.

Some transparent images need to be updated with opaque background.